### PR TITLE
Add double quotes with table name in query sql

### DIFF
--- a/main.pas
+++ b/main.pas
@@ -3475,8 +3475,8 @@ begin
   SelNode:= tvMain.Selected;
   if (SelNode <> nil) and (SelNode.Parent <> nil) then
   begin
-    QWindow:= ShowQueryWindow(SelNode.Parent.Parent.OverlayIndex, 'Select first 1000 from ' + SelNode.Text);
-    QWindow.meQuery.Lines.Text:= 'select first 1000 * from ' + SelNode.Text;
+    QWindow:= ShowQueryWindow(SelNode.Parent.Parent.OverlayIndex, 'Select first 1000 from "' + SelNode.Text + '"');
+    QWindow.meQuery.Lines.Text:= 'select first 1000 * from "' + SelNode.Text + '"';
     QWindow.bbRunClick(nil);
     QWindow.Show;
   end;


### PR DESCRIPTION
If table name contain non-ascii char, the query sql can execute normally after add double quotes with table name. 
Otherwise we would get 
"-Dynamic SQL Error
 -SQL error code = -104
 -Token unknown
"
