### PR TITLE
Fix to querywindow.pas

### DIFF
--- a/querywindow.pas
+++ b/querywindow.pas
@@ -1653,8 +1653,9 @@ begin
     OnCommit:= nil;
   end;
   FIBConnection.Close;
-  OutputTabsList.Free;
+  //   OutputTabsList.Free;  causes exception, still used in RemovePreviousResultTabs
   RemovePreviousResultTabs;
+  OutputTabsList.Free;
   CloseAction:= caFree;
 end;
 


### PR DESCRIPTION
Moved line 1656 below RemovePreviousResultTabs to fix exceptions in
Win32